### PR TITLE
Add new configuration into *Mojo: Ability to filter only file by file

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,4 +14,12 @@ The docker folder contains two images to build the plugin using java7 or
 java8
 
 
+Install Locally
+------
+
+By default jar is signed after packaging and before installation. To skip that (testing):
+```
+mvn -Dgpg.skip install
+```
+
 

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
 
             <plugin>
                 <artifactId>maven-release-plugin</artifactId>
-                <version>2.5.0</version>
+                <version>2.5.1</version>
                 <configuration>
                     <autoVersionSubmodules>true</autoVersionSubmodules>
                     <useReleaseProfile>false</useReleaseProfile>

--- a/pom.xml
+++ b/pom.xml
@@ -10,12 +10,6 @@
     <description>Manage placeholders and values in text file using mustache format.</description>
     <url>https://github.com/xebialabs-community/placeholders-mustachifier-maven-plugin</url>
 
-    <parent>
-        <groupId>sgcib.ctt.cascade</groupId>
-        <artifactId>cascade-root</artifactId>
-        <version>2.0.0-SNAPSHOT</version>
-    </parent>
-
     <licenses>
         <license>
             <name>The Apache Software License, Version 2.0</name>

--- a/pom.xml
+++ b/pom.xml
@@ -308,16 +308,16 @@
         <developerConnection>scm:git:git@github.com:xebialabs-community/mustachifier-maven-plugin.git</developerConnection>
     </scm>
 
-    <!--<distributionManagement>-->
-        <!--<snapshotRepository>-->
-            <!--<id>ossrh</id>-->
-            <!--<url>https://oss.sonatype.org/content/repositories/snapshots</url>-->
-        <!--</snapshotRepository>-->
-        <!--<repository>-->
-            <!--<id>ossrh</id>-->
-            <!--<url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>-->
-        <!--</repository>-->
-    <!--</distributionManagement>-->
+    <distributionManagement>
+        <snapshotRepository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
+        <repository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+        </repository>
+    </distributionManagement>
 
     <profiles>
         <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,6 @@
                     <notree>true</notree>
                     <nocomment>true</nocomment>
                     <nohelp>true</nohelp>
-                    <additionalparam>-Xdoclint:none</additionalparam>
                 </configuration>
                 <executions>
                     <execution>
@@ -338,6 +337,4 @@
             </build>
         </profile>
     </profiles>
-
-
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -10,6 +10,12 @@
     <description>Manage placeholders and values in text file using mustache format.</description>
     <url>https://github.com/xebialabs-community/placeholders-mustachifier-maven-plugin</url>
 
+    <parent>
+        <groupId>sgcib.ctt.cascade</groupId>
+        <artifactId>cascade-root</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
+    </parent>
+
     <licenses>
         <license>
             <name>The Apache Software License, Version 2.0</name>
@@ -111,7 +117,7 @@
                     <execution>
                         <id>attach-sources</id>
                         <goals>
-                            <goal>jar-no-fork</goal>
+                            <goal>jar</goal>
                         </goals>
                     </execution>
                 </executions>
@@ -126,6 +132,7 @@
                     <notree>true</notree>
                     <nocomment>true</nocomment>
                     <nohelp>true</nohelp>
+                    <additionalparam>-Xdoclint:none</additionalparam>
                 </configuration>
                 <executions>
                     <execution>
@@ -307,16 +314,16 @@
         <developerConnection>scm:git:git@github.com:xebialabs-community/mustachifier-maven-plugin.git</developerConnection>
     </scm>
 
-    <distributionManagement>
-        <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
-        <repository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-        </repository>
-    </distributionManagement>
+    <!--<distributionManagement>-->
+        <!--<snapshotRepository>-->
+            <!--<id>ossrh</id>-->
+            <!--<url>https://oss.sonatype.org/content/repositories/snapshots</url>-->
+        <!--</snapshotRepository>-->
+        <!--<repository>-->
+            <!--<id>ossrh</id>-->
+            <!--<url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>-->
+        <!--</repository>-->
+    <!--</distributionManagement>-->
 
     <profiles>
         <profile>

--- a/src/main/java/com/xebialabs/maven/mustache/AbstractMustachifierMojo.java
+++ b/src/main/java/com/xebialabs/maven/mustache/AbstractMustachifierMojo.java
@@ -91,7 +91,7 @@ public abstract class AbstractMustachifierMojo extends AbstractMojo {
         TFile input = new TFile(aFile.getSourceFile());
         TFile output = new TFile(aFile.getTargetFileName());
         try {
-            String content = load(input, aFile.getModelEncoding());
+            String content = TFiles.toString(input, Charset.forName(aFile.getModelEncoding()));
             if (aFile.isFilterOnlyMustacheProperties()) {
                 content = filterMustacheOnly(content);
             }
@@ -101,6 +101,8 @@ public abstract class AbstractMustachifierMojo extends AbstractMojo {
             save(processed, output, aFile.getModelEncoding());
         } catch (MojoExecutionException e) {
             getLog().error("Failed to read input file: "+input, e);
+        } catch (IOException e) {
+            getLog().warn("Failed to read input file: "+input);
         }
     }
 

--- a/src/main/java/com/xebialabs/maven/mustache/AbstractMustachifierMojo.java
+++ b/src/main/java/com/xebialabs/maven/mustache/AbstractMustachifierMojo.java
@@ -100,7 +100,7 @@ public abstract class AbstractMustachifierMojo extends AbstractMojo {
             parent.mkdirs();
             save(processed, output, aFile.getModelEncoding());
         } catch (MojoExecutionException e) {
-            getLog().error("Failed to read input file: "+input, e);
+            getLog().error("Failed to write output file: "+input, e);
         } catch (IOException e) {
             getLog().warn("Failed to read input file: "+input);
         }

--- a/src/main/java/com/xebialabs/maven/mustache/SingleFile.java
+++ b/src/main/java/com/xebialabs/maven/mustache/SingleFile.java
@@ -1,0 +1,54 @@
+package com.xebialabs.maven.mustache;
+
+/**
+ * Created by clalleme on 31/03/2015.
+ */
+public class SingleFile {
+    public static final String UTF_8 = "UTF-8";
+    String sourceFile;
+    String targetFileName;
+    boolean filterOnlyMustacheProperties = false;
+    private String modelEncoding = UTF_8;
+
+
+    public SingleFile() {
+    }
+
+    public SingleFile(final String aSourceFile, final String aTargetFileName, final boolean aFilterOnlyMustacheProperties) {
+        sourceFile = aSourceFile;
+        targetFileName = aTargetFileName;
+        filterOnlyMustacheProperties = aFilterOnlyMustacheProperties;
+    }
+
+    public String getSourceFile() {
+        return sourceFile;
+    }
+
+    public void setSourceFile(final String aSourceFile) {
+        sourceFile = aSourceFile;
+    }
+
+    public String getTargetFileName() {
+        return targetFileName;
+    }
+
+    public void setTargetFileName(final String aTargetFileName) {
+        targetFileName = aTargetFileName;
+    }
+
+    public boolean isFilterOnlyMustacheProperties() {
+        return filterOnlyMustacheProperties;
+    }
+
+    public void setFilterOnlyMustacheProperties(final boolean aFilterOnlyMustacheProperties) {
+        filterOnlyMustacheProperties = aFilterOnlyMustacheProperties;
+    }
+
+    public String getModelEncoding() {
+        return modelEncoding;
+    }
+
+    public void setModelEncoding(final String aModelEncoding) {
+        modelEncoding = aModelEncoding;
+    }
+}

--- a/src/main/java/com/xebialabs/maven/mustache/SingleFile.java
+++ b/src/main/java/com/xebialabs/maven/mustache/SingleFile.java
@@ -40,6 +40,17 @@ public class SingleFile {
         return filterOnlyMustacheProperties;
     }
 
+    /**
+     * Call this method when to want to retains only properties that contains mustache values.
+     * It can be useful when you want to
+     * <ul>
+     *     <li>Want to embark 'unmustachified' properties into a jarfile</li>
+     *     <li>And expose only 'mustachifed' properties into an external file (I means a file not into your classpath).
+     *     Use case is you don't want to show all properties to ops guys.</li>
+     * </ul>
+     *
+     * @param aFilterOnlyMustacheProperties
+     */
     public void setFilterOnlyMustacheProperties(final boolean aFilterOnlyMustacheProperties) {
         filterOnlyMustacheProperties = aFilterOnlyMustacheProperties;
     }

--- a/src/site/markdown/values-with-filtering-and-changing-target.md.vm
+++ b/src/site/markdown/values-with-filtering-and-changing-target.md.vm
@@ -1,0 +1,60 @@
+
+Values Generation
+=================
+
+With this configuration, the plugin:
+
+   * Select a standalone placeholders File.
+   * replaces any placeholders entries, eg: {{key:value}} or simple {{key}}, by a value provided by a Java Property file.
+   * Optionaly retains only value that contains {{key}}
+
+```
+    <plugin>
+        <groupId>com.xebialabs.utils</groupId>
+        <artifactId>placeholders-mustachifier-maven-plugin</artifactId>
+        <version>${project.version}</version>
+        <executions>
+            <execution>
+                <id>remove-mustache-for-testing</id>
+                <goals>
+                    <goal>mustache-tovalue</goal>
+                </goals>
+                <phase>generate-test-resources</phase>
+                <configuration>
+                    <files>
+                        <singlefile>
+                            <sourceFile>${basedir}/.../config.properties</sourceFile>
+                            <targetFileName>${project.build.testOutputDirectory}/limited-config.properties</targetFileName>
+                            <filterOnlyMustacheProperties>true</filterOnlyMustacheProperties>
+                        </singlefile>
+                    </files>
+                </configuration>
+            </execution>
+        </executions>
+    </plugin>
+```
+
+  
+the property file **before** the plugin execution (config.properties))
+
+    param1={{PARAM1:45}}
+    param2={{param22}}
+    param3=45
+    param4=http://{{host:localhost}}:{{port:8080}}/{{context:default}}
+    param5={{param5}}
+   
+using this property file as values:
+
+    PARAM1=45
+    param5=benoit
+    host=www.xebialabs.com
+    port=9090
+    context=xldeploy
+
+the property file **after** the plugin execution ()limited-config.properties)
+
+    param1=45
+    param2={{param22}}
+    param4=http://www.xebialabs.com:9090/xldeploy
+    param5=benoit
+

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -32,6 +32,8 @@
             <item name="Example: Generate Values" href="values.html"/>
             <item name="Example: Generate Values (Properties)" href="values-with-properties.html"/>
             <item name="Example: Generate Values (XLDeploy)" href="values-with-xldeploy.html"/>
+            <item name="Example: Filter Values and Change target filename" href="values-with-filtering-and-changing-target.html"/>
+
             <item name="Example: Generate Placeholders" href="placeholders.html"/>
             <item name="Example: Managing Archives" href="archives.html"/>
             <item name="Example: Switching between modes" href="modes.html"/>

--- a/src/test/java/com/xebialabs/maven/mustache/AbstractMustachifierMojoTest.java
+++ b/src/test/java/com/xebialabs/maven/mustache/AbstractMustachifierMojoTest.java
@@ -1,0 +1,46 @@
+package com.xebialabs.maven.mustache;
+
+import junit.framework.Assert;
+import org.apache.maven.shared.model.fileset.FileSet;
+import org.junit.Test;
+
+import java.util.ArrayList;
+
+import static org.junit.Assert.*;
+
+public class AbstractMustachifierMojoTest {
+
+    final static String lineBreak = System.getProperty("line.separator");
+
+    @Test
+    public void testSaveSingleFile() throws Exception {
+        MustachifierToValueMojo mojo = new MustachifierToValueMojo();
+        mojo.setValueSeparator(":");
+        mojo.setDelimiters("{{ }}");
+        mojo.setFilesets(new ArrayList<FileSet>());
+        mojo.saveSingleFile(new SingleFile("./target/test-classes/mustache/withplaceholders/config.properties", "./target/test-classes/mustache/withplaceholders/config-test.properties\\", false));
+    }
+
+    @Test
+    public void testSaveSingleFileWithFiltering() throws Exception {
+        MustachifierToValueMojo mojo = new MustachifierToValueMojo();
+        mojo.setValueSeparator(":");
+        mojo.setDelimiters("{{ }}");
+        mojo.setFilesets(new ArrayList<FileSet>());
+        mojo.saveSingleFile(new SingleFile("./target/test-classes/mustache/withplaceholders/config.properties", "./target/test-classes/mustache/withplaceholders/config-filter.properties\\", true));
+    }
+
+
+    @Test
+    public void testFilterMustacheOnly() throws Exception {
+        MustachifierToValueMojo mojo = new MustachifierToValueMojo();
+        mojo.setValueSeparator(":");
+        mojo.setDelimiters("{{ }}");
+
+        String content = "Boo=2"+lineBreak+"test={{fdfsf}}"+lineBreak;
+        String result = mojo.filterMustacheOnly(content);
+        System.err.println("result: "+result);
+        Assert.assertTrue(result.contains("test"));
+        Assert.assertFalse(result.contains("Boo"));
+    }
+}

--- a/src/test/java/com/xebialabs/maven/mustache/AbstractMustachifierMojoTest.java
+++ b/src/test/java/com/xebialabs/maven/mustache/AbstractMustachifierMojoTest.java
@@ -4,8 +4,12 @@ import junit.framework.Assert;
 import org.apache.maven.shared.model.fileset.FileSet;
 import org.junit.Test;
 
+import java.io.File;
 import java.util.ArrayList;
+import java.util.Properties;
 
+import static com.xebialabs.maven.mustache.MustachifierMojoTest.getPropertiesFromFile;
+import static com.xebialabs.maven.mustache.MustachifierToValueMojoTest.assertProperties;
 import static org.junit.Assert.*;
 
 public class AbstractMustachifierMojoTest {
@@ -14,20 +18,26 @@ public class AbstractMustachifierMojoTest {
 
     @Test
     public void testSaveSingleFile() throws Exception {
+        final String outputFileName = "./target/test-classes/mustache/withplaceholders/config-test.properties";
         MustachifierToValueMojo mojo = new MustachifierToValueMojo();
         mojo.setValueSeparator(":");
         mojo.setDelimiters("{{ }}");
         mojo.setFilesets(new ArrayList<FileSet>());
-        mojo.saveSingleFile(new SingleFile("./target/test-classes/mustache/withplaceholders/config.properties", "./target/test-classes/mustache/withplaceholders/config-test.properties\\", false));
+        mojo.saveSingleFile(new SingleFile("./target/test-classes/mustache/withplaceholders/config.properties", outputFileName, false));
+        Properties properties = getPropertiesFromFile(new File(outputFileName));
+        assertProperties(properties);
     }
 
     @Test
     public void testSaveSingleFileWithFiltering() throws Exception {
+        final String outputFileName = "./target/test-classes/mustache/withplaceholders/config-filter.properties";
         MustachifierToValueMojo mojo = new MustachifierToValueMojo();
         mojo.setValueSeparator(":");
         mojo.setDelimiters("{{ }}");
         mojo.setFilesets(new ArrayList<FileSet>());
-        mojo.saveSingleFile(new SingleFile("./target/test-classes/mustache/withplaceholders/config.properties", "./target/test-classes/mustache/withplaceholders/config-filter.properties\\", true));
+        mojo.saveSingleFile(new SingleFile("./target/test-classes/mustache/withplaceholders/config.properties", outputFileName, true));
+        Properties properties = getPropertiesFromFile(new File(outputFileName));
+        assertEquals(5, properties.size());
     }
 
 

--- a/src/test/java/com/xebialabs/maven/mustache/MustachifierMojoTest.java
+++ b/src/test/java/com/xebialabs/maven/mustache/MustachifierMojoTest.java
@@ -29,7 +29,7 @@ public abstract class MustachifierMojoTest extends AbstractMojoTestCase {
         super.tearDown();
     }
 
-    protected static Properties getPropertiesFromFile(final File targetFile) throws IOException {
+    static final Properties getPropertiesFromFile(final File targetFile) throws IOException {
         Properties properties = new Properties();
         properties.load(Files.newReader(targetFile, Charset.defaultCharset()));
         return properties;

--- a/src/test/java/com/xebialabs/maven/mustache/MustachifierToValueMojoTest.java
+++ b/src/test/java/com/xebialabs/maven/mustache/MustachifierToValueMojoTest.java
@@ -106,7 +106,7 @@ public class MustachifierToValueMojoTest extends MustachifierMojoTest {
         assertEquals("http://localhost:8080/default", properties.get("param4"));
     }
 
-    private void assertProperties(final Properties properties) {
+    final static void assertProperties(final Properties properties) {
         assertEquals(6, properties.size());
         assertEquals("45", properties.get("param1"));
         assertEquals("{{param22}}", properties.get("param2"));

--- a/src/test/java/com/xebialabs/maven/mustache/SingleFileTest.java
+++ b/src/test/java/com/xebialabs/maven/mustache/SingleFileTest.java
@@ -1,0 +1,17 @@
+package com.xebialabs.maven.mustache;
+
+import junit.framework.Assert;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class SingleFileTest {
+
+    @Test
+    public void should_contains_default_value() {
+        SingleFile file = new SingleFile();
+        Assert.assertEquals(SingleFile.UTF_8, file.getModelEncoding());
+        Assert.assertEquals(false, file.isFilterOnlyMustacheProperties());
+    }
+
+}


### PR DESCRIPTION
I need to filter file by file and change the location of result.
So I update the AbstractMojo to take into account new configuration property
I take the opportunity to mark filesets property as optional.
example of usage: 

```
<configuration>
    <files>
        <singlefile>
            <sourceFile>${project.build.directory}/config/${project.artifactId}.properties</sourceFile>
            <targetFileName>${project.build.testOutputDirectory}/${project.artifactId}.properties</targetFileName>
           <filterOnlyMustacheProperties>false</filterOnlyMustacheProperties>
        </singlefile>
    </files>
</configuration>
```
